### PR TITLE
Fixes Netflix timezone

### DIFF
--- a/network_timezones.txt
+++ b/network_timezones.txt
@@ -1245,7 +1245,7 @@ NEN (AU):Australia/Sydney
 neonalley.com (US):US/Eastern
 NET 5:Europe/Amsterdam
 Netflix (UK):Europe/London
-Netflix:US/Eastern
+Netflix:US/Pacific
 Network Ten:Australia/Sydney
 NEW (AU):Australia/Sydney
 New England Sports Network (US):US/Eastern


### PR DESCRIPTION
Updated the timezone for Netflix to US/Pacific because that is the timezone they use to determine when shows are being released.