### PR TITLE
Adds AVROTROS network

### DIFF
--- a/network_timezones.txt
+++ b/network_timezones.txt
@@ -180,6 +180,7 @@ aurora (AU):Australia/Sydney
 Australian Christian Channel:Australia/Sydney
 aux (CA):Canada/Eastern
 AVRO:Europe/Amsterdam
+AVROTROS:Europe/Amsterdam
 AWE (US):US/Eastern
 AXN (HK):Asia/Hong_Kong
 AXN (JP):Asia/Tokyo


### PR DESCRIPTION
According to google in 2014 the networks AVRO and TROS merged to become AVROTROS, which isn't currently in the list. Currently the show [The Mole (NL)](http://thetvdb.com/?tab=series&id=81391) is affected, but there may be others.