### PR TITLE
Fix casing for Showcase (AU)

### DIFF
--- a/network_timezones.txt
+++ b/network_timezones.txt
@@ -1604,7 +1604,7 @@ SHO NEXT (US):US/Eastern
 sho.com (US):US/Eastern
 Shopping Channel (CA):Canada/Eastern
 Show TV:Europe/Istanbul
-showcase (AU):Australia/Sydney
+Showcase (AU):Australia/Sydney
 Showcase (CA):Canada/Eastern
 Showcase (UK):Europe/London
 SHOWCASE (US):US/Eastern


### PR DESCRIPTION
I checked for any uses of `showcase (AU)`, but it looks like the only usages are `Showcase (AU)`, so this fixes it to match exactly.