### PR TITLE
Change Netflix to US/Eastern

### DIFF
--- a/network_timezones.txt
+++ b/network_timezones.txt
@@ -1411,7 +1411,7 @@ National Jewish Television (US):US/Eastern
 Nejat TV (US):US/Eastern
 Nelonen:Europe/Helsinki
 Neox:Europe/Madrid
-Netflix:US/Pacific
+Netflix:US/Eastern
 Netflix (UK):Europe/London
 Network Ten:Australia/Sydney
 New England Sports Network (US):US/Eastern


### PR DESCRIPTION
TheTVDB is going to standardize the timezone for US shows to Eastern (and a good chunk of shows have already been updated to that prior to their decision, AKA it's a mess). Given their stance/plans moving forward it'd be best to update it to EST and any remaining shows can be updated as people get to them.

https://forums.thetvdb.com/viewtopic.php?f=41&t=56973